### PR TITLE
Fix m_uniformNames Iterator

### DIFF
--- a/src/render/materialsystem/shader.cpp
+++ b/src/render/materialsystem/shader.cpp
@@ -375,7 +375,7 @@ void Shader::initializeUniformBlocks(const QVector<ShaderUniformBlock> &uniformB
         const QVector<ShaderUniform>::const_iterator uniformsEnd = m_uniforms.end();
 
         QVector<QString>::const_iterator uniformNamesIt = m_uniformsNames.begin();
-        const QVector<QString>::const_iterator uniformNamesEnd = m_attributesNames.end();
+        const QVector<QString>::const_iterator uniformNamesEnd = m_uniformsNames.end();
 
         QHash<QString, ShaderUniform> activeUniformsInBlock;
 


### PR DESCRIPTION
I'm new to the source, but this seems to be wrong at first glance since it was using the attributes instead of the uniforms. Could you verify the change is what should be intended? It's doubtful that this would be a problem since it checks the m_uniforms collections too, but just to be safe.